### PR TITLE
Eases include of CliBrowser

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Demo
 ----
 ![demo gif](docs/images/demo.gif)
 ```
-from cli_browser import CliBrowser
+from pydrivebrowser import CliBrowser
 
 c = CliBrowser()
 url = 'https://drive.google.com/drive/folders/1APzr67aMpXSkcMNlA0rWaJHvMoXwb9o8?usp=sharing'

--- a/pydrivebrowser/__init__.py
+++ b/pydrivebrowser/__init__.py
@@ -1,0 +1,1 @@
+from pydrivebrowser.cli_browser import CliBrowser


### PR DESCRIPTION
Eases include of CliBrowser by including it in
pydriverbrowser/__init__.py. This allows the user to include it through `from pydrivebrowser import CliBrowser`